### PR TITLE
test: sentry in debug build

### DIFF
--- a/.github/workflows/debug-build.yml
+++ b/.github/workflows/debug-build.yml
@@ -120,6 +120,7 @@ jobs:
           BRANCH_NAME: ${{ steps.vars.outputs.branch_name }}
           CSC_LINK: ${{ secrets[matrix.CSC_LINK_SECRET_NAME] }}
           CSC_KEY_PASSWORD: ${{ secrets[matrix.CSC_KEY_PASSWORD_SECRET_NAME] }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS }}
 


### PR DESCRIPTION
> [Download the latest build](https://github.com/hirosystems/stacks-wallet/actions/runs/1411623759)<!-- Sticky Header Marker -->

Doh. It was just missing the env var in debug 🤦🏼 