### PR TITLE
fix: entitlement issue

### DIFF
--- a/resources/entitlements.mac.plist
+++ b/resources/entitlements.mac.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
-	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>


### PR DESCRIPTION
> [Download the latest build](https://github.com/hirosystems/stacks-wallet/actions/runs/1615444279)<!-- Sticky Header Marker -->

Removes an unnecessary entitlement https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_allow-dyld-environment-variables 

This was originally added around mainnet launch to ensure Ledger's would work on hardened wallets, though it seems it wasn't necessary.