### PR TITLE
refactor: persist public key and derive address

### DIFF
--- a/app/components/title-bar/title-bar.tsx
+++ b/app/components/title-bar/title-bar.tsx
@@ -26,6 +26,8 @@ export const TitleBar: FC = () => {
 
   const isBlurred = winState === 'blurred';
   const isOnboarding = matchPath(location.pathname, { path: '/onboard' }) !== null;
+  const isLocked = matchPath(location.pathname, { path: routes.UNLOCK }) !== null;
+  const showSettingButton = !isOnboarding && !isLocked;
 
   if (!el) return null;
 
@@ -63,7 +65,7 @@ export const TitleBar: FC = () => {
       </Flex>
       <Stack alignItems="center" pr="base-loose" isInline spacing="tight">
         <ColorModeButton color={color('text-title')} />
-        {!isOnboarding && (
+        {showSettingButton && (
           <SettingsButton
             onClick={() => routerHistory.push(routes.SETTINGS)}
             color={color('text-title')}

--- a/app/constants/routes.json
+++ b/app/constants/routes.json
@@ -14,5 +14,6 @@
   "CHOOSE_STACKING_METHOD": "/choose-stacking-method",
   "STACKING": "/stacking",
   "DELEGATED_STACKING": "/delegated-stacking",
-  "SETTINGS": "/settings"
+  "SETTINGS": "/settings",
+  "UNLOCK": "/unlock"
 }

--- a/app/pages/Unlock.tsx
+++ b/app/pages/Unlock.tsx
@@ -1,0 +1,81 @@
+import React, { useCallback, useState } from 'react';
+import { DecryptWalletForm } from '@modals/components/decrypt-wallet-form';
+import { safeAwait } from '@utils/safe-await';
+import { isDecryptionError } from '@crypto/key-encryption';
+import { useDecryptWallet } from '@hooks/use-decrypt-wallet';
+import { createStacksPrivateKey, getPublicKey, publicKeyToString } from '@stacks/transactions';
+import { Box } from '@stacks/ui';
+import { Onboarding, OnboardingButton, OnboardingTitle } from '@components/onboarding';
+import { useBackButton } from '@hooks/use-back-url';
+import { ResetWalletModal } from '@modals/reset-wallet/reset-wallet-modal';
+import { persistPublicKey } from '@utils/disk-store';
+import { useHistory } from 'react-router';
+import routes from '@constants/routes.json';
+import { useDispatch } from 'react-redux';
+import { setPublicKey } from '@store/keys';
+
+export const Unlock: React.FC = () => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  useBackButton(null);
+  const [password, setPassword] = useState('');
+  const [resetModalOpen, setResetModalOpen] = useState(false);
+  const [decryptionError, setDecryptionError] = useState<string | null>(null);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+  const { decryptWallet, isDecrypting } = useDecryptWallet();
+
+  const derivePublicKey = useCallback(async () => {
+    const { privateKey } = await decryptWallet(password);
+    const senderKey = createStacksPrivateKey(privateKey);
+    return publicKeyToString(getPublicKey(senderKey));
+  }, [password, decryptWallet]);
+
+  const onUnlockClick = async () => {
+    setHasSubmitted(true);
+    setIsBusy(true);
+    const [error, publicKey] = await safeAwait(derivePublicKey());
+    if (error) {
+      setDecryptionError(
+        isDecryptionError(error) ? 'Unable to decrypt wallet' : 'Something went wrong'
+      );
+      setIsBusy(false);
+    }
+    if (publicKey) {
+      dispatch(setPublicKey(publicKey));
+      await persistPublicKey(publicKey);
+      history.push(routes.HOME);
+    } else {
+      setDecryptionError('Something went wrong');
+    }
+  };
+
+  return (
+    <>
+      <ResetWalletModal isOpen={resetModalOpen} onClose={() => setResetModalOpen(false)} />
+      <Onboarding>
+        <Box mx="extra-loose" mt="extra-loose">
+          <OnboardingTitle textAlign={'left'}>Welcome back!</OnboardingTitle>
+        </Box>
+        <DecryptWalletForm
+          description={`Enter your password`}
+          onSetPassword={password => setPassword(password)}
+          onForgottenPassword={() => setResetModalOpen(true)}
+          hasSubmitted={hasSubmitted}
+          decryptionError={decryptionError}
+        />
+        <Box mx="extra-loose" mt="extra-loose">
+          <OnboardingButton
+            type="submit"
+            mt="loose"
+            isLoading={isDecrypting || isBusy}
+            isDisabled={isDecrypting || isBusy}
+            onClick={onUnlockClick}
+          >
+            Unlock
+          </OnboardingButton>
+        </Box>
+      </Onboarding>
+    </>
+  );
+};

--- a/app/pages/onboarding/05-connect-ledger/connect-ledger.tsx
+++ b/app/pages/onboarding/05-connect-ledger/connect-ledger.tsx
@@ -65,7 +65,6 @@ export const ConnectLedger: React.FC = () => {
         }
         dispatch(
           setLedgerWallet({
-            address: deviceResponse.address,
             publicKey: deviceResponse.publicKey,
             onSuccess: () => history.push(routes.HOME),
           })

--- a/app/routes.tsx
+++ b/app/routes.tsx
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/react';
 
 import routes from './constants/routes.json';
 import { Home } from './pages/home/home';
-import { selectAddress } from './store/keys/keys.reducer';
+import { selectSignedIn, selectPublicKey } from '@store/keys';
 
 import {
   Terms,
@@ -27,6 +27,7 @@ import { StackingDelegation } from './pages/stacking/delegated-stacking/pooled-s
 import { useHasUserGivenDiagnosticPermissions } from '@store/settings';
 import { Diagnostics } from './pages/onboarding/01-diagnostics/diagnostics';
 import { initSegment } from '@utils/init-segment';
+import { Unlock } from './pages/Unlock';
 
 initSegment();
 
@@ -101,9 +102,21 @@ export const routerConfig = [
     path: routes.STACKING,
     component: DirectStacking,
   },
+  {
+    path: routes.UNLOCK,
+    component: Unlock,
+  },
 ];
 
-const getAppStartingRoute = (address?: string) => (!!address ? routes.HOME : routes.TERMS);
+const getAppStartingRoute = (publicKey: Buffer | null, signedIn: boolean) => {
+  if (!signedIn) {
+    return routes.TERMS;
+  }
+  if (!publicKey) {
+    return routes.UNLOCK;
+  }
+  return routes.HOME;
+};
 
 export function Routes() {
   // `useStore` required as we only want the value on initial render
@@ -129,7 +142,8 @@ export function Routes() {
     setUserDisabledDiagnosticsInCurrentSession(!diagnosticPermission);
   }, [diagnosticPermission]);
 
-  const address = selectAddress(store.getState());
+  const signedIn = selectSignedIn(store.getState());
+  const publicKey = selectPublicKey(store.getState());
   return (
     <App>
       <Switch>
@@ -137,7 +151,7 @@ export function Routes() {
           <Route key={i} exact {...route} />
         ))}
       </Switch>
-      <Redirect to={getAppStartingRoute(address)} />
+      <Redirect to={getAppStartingRoute(publicKey, signedIn)} />
     </App>
   );
 }

--- a/app/utils/disk-store.ts
+++ b/app/utils/disk-store.ts
@@ -3,32 +3,28 @@ import { WalletType } from '../models/wallet-type';
 enum StoreIndex {
   Salt = 'salt',
   EncryptedMnemonic = 'encryptedMnemonic',
-  StxAddress = 'stxAddress',
   PublicKey = 'publicKey',
   WalletType = 'walletType',
+  SignedIn = 'signedIn',
 }
 
 interface SoftwareWallet {
   [StoreIndex.WalletType]: 'software';
   [StoreIndex.Salt]: string;
   [StoreIndex.EncryptedMnemonic]: string;
-  [StoreIndex.StxAddress]: string;
+  [StoreIndex.SignedIn]: boolean;
 }
 
 interface LedgerWallet {
   [StoreIndex.WalletType]: 'ledger';
-  [StoreIndex.StxAddress]: string;
   [StoreIndex.PublicKey]: string;
+  [StoreIndex.SignedIn]: boolean;
 }
 
 export type DiskStore = LedgerWallet | SoftwareWallet;
 
 export const persistEncryptedMnemonic = async (encryptedMnemonic: string) => {
   return main.store.set(StoreIndex.EncryptedMnemonic, encryptedMnemonic);
-};
-
-export const persistStxAddress = async (stxAddress: string) => {
-  return main.store.set(StoreIndex.StxAddress, stxAddress);
 };
 
 export const persistPublicKey = async (publicKey: string) => {
@@ -41,6 +37,10 @@ export const persistSalt = async (salt: string) => {
 
 export const persistWalletType = async (walletType: WalletType) => {
   return main.store.set(StoreIndex.WalletType, walletType);
+};
+
+export const persistSignedIn = async () => {
+  return main.store.set(StoreIndex.SignedIn, true);
 };
 
 export const getInitialStateFromDisk = () => {


### PR DESCRIPTION
> [Download the latest build](https://github.com/hirosystems/stacks-wallet/actions/runs/1987558644)<!-- Sticky Header Marker -->

This refactor aims to pave the way to restructure transaction signing and use the new fee estimation mechanism.

- Persist public key, remove `stxAddress` and derive it from public key (closes #842)
- Add `locked` view: when public key is missing, wallet will show a locked screen asking for password then persist public key.
- Add `initialized` state
  - Remove the dependency between address/public key existence and app starting route (missing address/public key doesn't mean wallet isn't initialized)
  - At any point, we can remove the public key to lock the wallet, other wallets have this as user config (auto-lock timer).